### PR TITLE
Update to canHandleResource

### DIFF
--- a/src/main/actionscript/com/castlabs/dash/DashPlugin.as
+++ b/src/main/actionscript/com/castlabs/dash/DashPlugin.as
@@ -13,6 +13,7 @@ import org.osmf.elements.VideoElement;
 import org.osmf.media.MediaElement;
 import org.osmf.media.MediaResourceBase;
 import org.osmf.media.PluginInfo;
+import org.osmf.media.URLResource;
 
 public class DashPlugin extends Sprite {
     private var _pluginInfo:PluginInfo;
@@ -32,7 +33,17 @@ public class DashPlugin extends Sprite {
     }
 
     public static function canHandleResource(resource:MediaResourceBase):Boolean {
-        return true;
+		var urlResource:URLResource = resource as URLResource;
+		
+		if (!urlResource || !urlResource.url)
+		{
+			return false;
+		}
+		
+		var url:String = urlResource.url;
+		var extension:String = url.substring(url.lastIndexOf('.')+1, url.length).toLowerCase();
+		
+		return extension == 'mpd';
     }
 
     public static function mediaElementCreationFunction():MediaElement {


### PR DESCRIPTION
I modified `canHandleResource` to detect DASH content, rather than always returning `true`, to enable playback of non-DASH content after the Dash.as plugin is loaded by OSMF.

Without this modification, OSMF tries to play all content through the Dash.as plugin, meaning it gets stuck in a `loading` state forever. This is obviously a problem if you'd like to be able to play DASH, HDS and/or MP4 content with a single player, for example.