### PR TITLE
Enabled playback of non-DASH content with DASH.as plugin loaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,12 @@
 bin-debug/
 
 # Flash Builder
+.settings
 .flexProperties
+.flexLibProperties
 .actionScriptProperties
 .project
+bin
 
 # Maven
 target/
@@ -23,4 +26,3 @@ rsync.sh
 rsync_vanilla.sh
 libs/
 Flash Player Debugger.app/
-

--- a/src/main/actionscript/com/castlabs/dash/DashPlugin.as
+++ b/src/main/actionscript/com/castlabs/dash/DashPlugin.as
@@ -41,10 +41,11 @@ public class DashPlugin extends Sprite {
 			return false;
 		}
 		
-		var url:String = urlResource.url.toLowerCase();
+		var url:String = urlResource.url;
 		
-        return url.indexOf('.mpd') != -1
-			|| url.indexOf('.dash') != -1;
+        return /\.mpd/i.test(url)
+			|| /\.dash/i.test(url)
+			;
     }
 	
     public static function mediaElementCreationFunction():MediaElement {

--- a/src/main/actionscript/com/castlabs/dash/DashPlugin.as
+++ b/src/main/actionscript/com/castlabs/dash/DashPlugin.as
@@ -13,6 +13,7 @@ import org.osmf.elements.VideoElement;
 import org.osmf.media.MediaElement;
 import org.osmf.media.MediaResourceBase;
 import org.osmf.media.PluginInfo;
+import org.osmf.media.URLResource;
 
 public class DashPlugin extends Sprite {
     private var _pluginInfo:PluginInfo;
@@ -32,9 +33,20 @@ public class DashPlugin extends Sprite {
     }
 
     public static function canHandleResource(resource:MediaResourceBase):Boolean {
-        return true;
+		
+		var urlResource:URLResource = resource as URLResource;
+		
+		if (!urlResource || !urlResource.url)
+		{
+			return false;
+		}
+		
+		var url:String = urlResource.url.toLowerCase();
+		
+        return url.indexOf('.mpd') != -1
+			|| url.indexOf('.dash') != -1;
     }
-
+	
     public static function mediaElementCreationFunction():MediaElement {
         return new VideoElement(null, DashContext.getInstance().dashNetLoader);
     }


### PR DESCRIPTION
I've modified the `canHandleResource` method in `DashPlugin.as` to identify whether or not the stream is DASH, rather than always returning `true`.

Without this modification, it is not possible to play non-DASH content while the DASH.as plugin loaded.
